### PR TITLE
refactor(core): make protocol endian-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,30 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
-name = "bitcode"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1bce7608560cd4bf0296a4262d0dbf13e6bcec5ff2105724c8ab88cc7fc784"
-dependencies = [
- "arrayvec",
- "bitcode_derive",
- "bytemuck",
- "glam",
- "serde",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a539389a13af092cd345a2b47ae7dec12deb306d660b2223d25cd3419b253ebe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,7 +626,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bitcode",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -667,6 +642,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "speedy",
  "tokenizers",
  "tokio",
  "tracing-chrome",
@@ -1572,12 +1548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +1973,15 @@ checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3048,6 +3027,27 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "speedy"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1992073f0e55aab599f4483c460598219b4f9ff0affa124b33580ab511e25a"
+dependencies = [
+ "memoffset",
+ "speedy-derive",
+]
+
+[[package]]
+name = "speedy-derive"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f2ca5276b92c3dfd65fa88316b4e032ace68f88d7570b43967784c0bac5ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cake-core/Cargo.toml
+++ b/cake-core/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
-bitcode = { version = "0.6.0", features = ["serde"] }
 
 clap = { version = "4.5.8", features = ["derive"] }
 human_bytes = "0.4.3"
@@ -19,6 +18,7 @@ safetensors = "0.4.3"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.120"
 serde_yaml = "0.9.34"
+speedy = "0.8.7"
 tokenizers = { version = "0.19.1", features = ["onig"] }
 tokio = { version = "1.38.0", features = ["full"] }
 yoke = { version = "0.7.4", features = ["derive"] }


### PR DESCRIPTION
I replaced `bitcode` with `speedy` so I can serialize integers in big endian, same thing for magic code and message length.