### PR TITLE
fix: fix second inference error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,8 +633,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "candle-core 0.6.1",
- "candle-nn 0.6.1",
+ "candle-core",
+ "candle-nn",
  "candle-transformers",
  "clap",
  "hf-hub",
@@ -676,8 +676,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cake-core",
- "candle-core 0.6.0",
- "candle-nn 0.6.0",
+ "candle-core",
+ "candle-nn",
  "clap",
  "memmap2",
  "safetensors",
@@ -702,26 +702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5b18de020c2729dbf7ac390325312644808b6ba9b7962f1f724e9185b1d53c7"
 dependencies = [
  "byteorder",
- "gemm",
- "half",
- "memmap2",
- "num-traits",
- "num_cpus",
- "rand",
- "rand_distr",
- "rayon",
- "safetensors",
- "thiserror",
- "yoke",
- "zip",
-]
-
-[[package]]
-name = "candle-core"
-version = "0.6.1"
-source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
-dependencies = [
- "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
  "cudarc",
@@ -742,16 +722,18 @@ dependencies = [
 
 [[package]]
 name = "candle-kernels"
-version = "0.6.1"
-source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0a71be8b2f0950b63fd602a5e10a74a4f94a5fd63059ae455e96163389488"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.6.1"
-source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f889aacd02fd999620a0435133d7cf3b58c81ef9dd5e47c38939b7a72345ea86"
 dependencies = [
  "metal",
  "once_cell",
@@ -765,21 +747,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b006b30f66a0d94fc9cef0ac4de6ce510565f35ae2c6c35ce5d4aacfb0fc8eeb"
 dependencies = [
- "candle-core 0.6.0",
- "half",
- "num-traits",
- "rayon",
- "safetensors",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "candle-nn"
-version = "0.6.1"
-source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
-dependencies = [
- "candle-core 0.6.1",
+ "candle-core",
  "candle-metal-kernels",
  "half",
  "metal",
@@ -792,12 +760,13 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.6.1"
-source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0d4eb6a0d9279d5829b06b2bf3caa117904eefd6dcf879d16e687c4a84034c"
 dependencies = [
  "byteorder",
- "candle-core 0.6.1",
- "candle-nn 0.6.1",
+ "candle-core",
+ "candle-nn",
  "fancy-regex",
  "num-traits",
  "rand",
@@ -1028,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.12.1"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd60a9a42ec83a2ed7effb0b1f073270264ea99da7acfc44f7e8d74dee0384"
+checksum = "7a5bd4d1eee570c3b2ac64ed114125517dd1e541d88dd28fc259f1de4dba8d60"
 dependencies = [
  "half",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02303ce8d4e8be5b855af6cf3c3a08f3eff26880faad82bab679c22d3650cb5"
+checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.8.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -155,6 +155,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -186,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
@@ -198,6 +199,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -244,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -259,33 +266,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -293,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -319,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "askama"
@@ -379,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -419,17 +426,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -508,9 +515,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitstream-io"
-version = "2.5.0"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcde5f311c85b8ca30c2e4198d4326bc342c76541590106f5fa4a50946ea499"
+checksum = "b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452"
 
 [[package]]
 name = "block"
@@ -562,18 +569,18 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -594,9 +601,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "bytestring"
@@ -626,8 +633,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "candle-core",
- "candle-nn",
+ "candle-core 0.6.1",
+ "candle-nn 0.6.1",
  "candle-transformers",
  "clap",
  "hf-hub",
@@ -669,8 +676,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cake-core",
- "candle-core",
- "candle-nn",
+ "candle-core 0.6.0",
+ "candle-nn 0.6.0",
  "clap",
  "memmap2",
  "safetensors",
@@ -681,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -693,6 +700,26 @@ name = "candle-core"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5b18de020c2729dbf7ac390325312644808b6ba9b7962f1f724e9185b1d53c7"
+dependencies = [
+ "byteorder",
+ "gemm",
+ "half",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror",
+ "yoke",
+ "zip",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.6.1"
+source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -715,18 +742,16 @@ dependencies = [
 
 [[package]]
 name = "candle-kernels"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc0a71be8b2f0950b63fd602a5e10a74a4f94a5fd63059ae455e96163389488"
+version = "0.6.1"
+source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f889aacd02fd999620a0435133d7cf3b58c81ef9dd5e47c38939b7a72345ea86"
+version = "0.6.1"
+source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
 dependencies = [
  "metal",
  "once_cell",
@@ -740,7 +765,21 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b006b30f66a0d94fc9cef0ac4de6ce510565f35ae2c6c35ce5d4aacfb0fc8eeb"
 dependencies = [
- "candle-core",
+ "candle-core 0.6.0",
+ "half",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.6.1"
+source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
+dependencies = [
+ "candle-core 0.6.1",
  "candle-metal-kernels",
  "half",
  "metal",
@@ -753,13 +792,12 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0d4eb6a0d9279d5829b06b2bf3caa117904eefd6dcf879d16e687c4a84034c"
+version = "0.6.1"
+source = "git+https://github.com/lucky9-cyou/candle?branch=feat/update-cudarc-0.12.1#8db44740f7d56039682ca8b78a59e77c9b0d242a"
 dependencies = [
  "byteorder",
- "candle-core",
- "candle-nn",
+ "candle-core 0.6.1",
+ "candle-nn 0.6.1",
  "fancy-regex",
  "num-traits",
  "rand",
@@ -795,12 +833,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -821,9 +860,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -831,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -843,11 +882,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -855,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "color_quant"
@@ -867,9 +906,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console"
@@ -913,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics-types"
@@ -930,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -989,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.11.8"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56028291ec3b0f6711e2e1b2d597484d359833dcb68331ce89e538012f835c4"
+checksum = "38cd60a9a42ec83a2ed7effb0b1f073270264ea99da7acfc44f7e8d74dee0384"
 dependencies = [
  "half",
  "libloading",
@@ -1054,18 +1093,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1075,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -1171,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1183,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -1193,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1239,7 +1278,7 @@ dependencies = [
  "flume",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1258,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
@@ -1273,12 +1312,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1543,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -1602,12 +1641,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1729,10 +1762,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
-name = "indexmap"
-version = "2.2.6"
+name = "impl-more"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1773,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1803,9 +1842,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1836,9 +1875,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1853,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -1967,9 +2006,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -2042,15 +2081,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2202,18 +2251,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2248,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2408,14 +2457,14 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -2425,17 +2474,20 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2468,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.18.21"
+version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec8d02258294f59e4e223b41ad7e81c874aa6b15bc4ced9ba3965826da0eed5"
+checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
 dependencies = [
  "bytemuck",
  "libm",
@@ -2495,9 +2547,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2579,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5797d09f9bd33604689e87e8380df4951d4912f01b63f71205e2abd4ae25e6b6"
+checksum = "a8f0bfd976333248de2078d350bfdf182ff96e168a24d23d2436cef320dd4bdd"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -2639,18 +2691,18 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2659,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2694,9 +2746,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rgb"
-version = "0.8.45"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -2724,18 +2776,18 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2746,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "log",
  "once_cell",
@@ -2761,15 +2813,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2784,9 +2836,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safetensors"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ced76b22c7fba1162f11a5a75d9d8405264b467a07ae0c9c29be119b9297db9"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2803,11 +2855,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2876,18 +2928,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2896,11 +2948,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2967,6 +3020,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3097,9 +3156,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3138,28 +3197,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck 0.5.0",
+ "heck",
  "pkg-config",
- "toml 0.8.15",
+ "toml 0.8.19",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3292,28 +3352,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3322,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3344,47 +3403,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.16",
+ "winnow",
 ]
 
 [[package]]
@@ -3479,15 +3527,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -3503,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3521,12 +3569,13 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "uniffi"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31bff6daf87277a9014bcdefbc2842b0553392919d1096843c5aad899ca4588"
+checksum = "2db87def739fe4183947f8419d572d1849a4a09355eba4e988a2105cfd0ac6a7"
 dependencies = [
  "anyhow",
  "camino",
+ "cargo_metadata",
  "clap",
  "uniffi_bindgen",
  "uniffi_core",
@@ -3535,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96061d7e01b185aa405f7c9b134741ab3e50cc6796a47d6fd8ab9a5364b5feed"
+checksum = "7a112599c9556d1581e4a3d72019a74c2c3e122cc27f4af12577a429c4d5e614"
 dependencies = [
  "anyhow",
  "askama",
@@ -3546,22 +3595,21 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin",
- "heck 0.5.0",
+ "heck",
  "once_cell",
  "paste",
  "serde",
  "textwrap",
  "toml 0.5.11",
  "uniffi_meta",
- "uniffi_testing",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcfa22f55829d3aaa7acfb1c5150224188fe0f27c59a8a3eddcaa24d1ffbe58"
+checksum = "a22dbe67c1c957ac6e7611bdf605a6218aa86b0eebeb8be58b70ae85ad7d73dc"
 dependencies = [
  "quote",
  "syn",
@@ -3569,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3210d57d6ab6065ab47a2898dacdb7c606fd6a4156196831fa3bf82e34ac58a6"
+checksum = "5a0c35aaad30e3a9e6d4fe34e358d64dbc92ee09045b48591b05fc9f12e0905b"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3585,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58691741080935437dc862122e68d7414432a11824ac1137868de46181a0bd2"
+checksum = "db66474c5c61b0f7afc3b4995fecf9b72b340daa5ca0ef3da7778d75eb5482ea"
 dependencies = [
  "bincode",
  "camino",
@@ -3603,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
+checksum = "d898893f102e0e39b8bcb7e3d2188f4156ba280db32db9e8af1f122d057e9526"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3615,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f922465f7566f25f8fe766920205fdfa9a3fcdc209c6bfb7557f0b5bf45b04dd"
+checksum = "2c6aa4f0cf9d12172d84fc00a35a6c1f3522b526daad05ae739f709f6941b9b6"
 dependencies = [
  "anyhow",
  "camino",
@@ -3628,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef408229a3a407fafa4c36dc4f6ece78a6fb258ab28d2b64bddd49c8cb680f6"
+checksum = "6b044e9c519e0bb51e516ab6f6d8f4f4dcf900ce30d5ad07c03f924e2824f28e"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -3653,9 +3701,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -3727,9 +3775,9 @@ checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3749,19 +3797,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -3774,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3784,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3797,15 +3846,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3843,11 +3892,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3870,6 +3919,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3997,18 +4055,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -4043,6 +4092,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -4110,18 +4160,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/cake-cli/src/main.rs
+++ b/cake-cli/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     // setup logging
     if std::env::var_os("RUST_LOG").is_none() {
         // set `RUST_LOG=debug` to see debug logs
-        std::env::set_var("RUST_LOG", "debug,tokenizers=error,actix_server=warn");
+        std::env::set_var("RUST_LOG", "info,tokenizers=error,actix_server=warn");
     }
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))

--- a/cake-core/src/cake/api/image.rs
+++ b/cake-core/src/cake/api/image.rs
@@ -1,20 +1,20 @@
+use crate::cake::Master;
+use crate::models::ImageGenerator;
+use crate::models::TextGenerator;
+use crate::ImageGenerationArgs;
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use base64::engine::general_purpose;
+use base64::Engine;
+use image::{DynamicImage, ImageFormat};
+use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::Mutex;
-use actix_web::{HttpRequest, HttpResponse, Responder, web};
-use base64::Engine;
-use base64::engine::general_purpose;
-use image::{DynamicImage, ImageFormat};
-use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use crate::cake::Master;
-use crate::ImageGenerationArgs;
-use crate::models::TextGenerator;
-use crate::models::ImageGenerator;
 
 #[derive(Deserialize)]
 pub struct ImageRequest {
-    pub image_args: ImageGenerationArgs
+    pub image_args: ImageGenerationArgs,
 }
 
 #[derive(Serialize)]
@@ -40,28 +40,31 @@ where
     let result_images = Arc::new(Mutex::new(Vec::new()));
     let result_images_cloned = Arc::clone(&result_images);
 
-    master.generate_image(image_request.image_args.clone(),  move |images|{
+    master
+        .generate_image(image_request.image_args.clone(), move |images| {
+            let mut base64_images: Vec<String> = images
+                .iter()
+                .map(|image| {
+                    let dynamic_image = DynamicImage::ImageRgb8(image.clone());
+                    let mut png_bytes = Vec::new();
+                    let mut cursor = Cursor::new(&mut png_bytes);
+                    dynamic_image
+                        .write_to(&mut cursor, ImageFormat::Png)
+                        .unwrap();
+                    general_purpose::STANDARD.encode(png_bytes)
+                })
+                .collect();
 
-        let mut base64_images: Vec<String> = images
-        .iter()
-        .map(|image| {
-
-            let dynamic_image = DynamicImage::ImageRgb8(image.clone());
-            let mut png_bytes = Vec::new();
-            let mut cursor = Cursor::new(&mut png_bytes);
-            dynamic_image.write_to(&mut cursor, ImageFormat::Png).unwrap();
-            general_purpose::STANDARD.encode(png_bytes)
+            let mut locked_result_images =
+                result_images_cloned.lock().expect("Error acquiring lock");
+            locked_result_images.append(&mut base64_images);
         })
-        .collect();
-
-        let mut locked_result_images = result_images_cloned.lock().expect("Error acquiring lock");
-        locked_result_images.append(&mut base64_images);
-    }).await.expect("Error generating images");
-
+        .await
+        .expect("Error generating images");
 
     let locked_result_images = result_images.lock().expect("Error acquiring lock");
-    let response = ImageResponse{
-        images: locked_result_images.to_vec()
+    let response = ImageResponse {
+        images: locked_result_images.to_vec(),
     };
 
     HttpResponse::Ok().json(response)

--- a/cake-core/src/cake/api/mod.rs
+++ b/cake-core/src/cake/api/mod.rs
@@ -35,7 +35,10 @@ where
         move || {
             App::new()
                 .app_data(web::Data::new(state.clone()))
-                .route("/api/v1/chat/completions", web::post().to(generate_text::<TG, IG>))
+                .route(
+                    "/api/v1/chat/completions",
+                    web::post().to(generate_text::<TG, IG>),
+                )
                 .route("/api/v1/image", web::post().to(generate_image::<TG, IG>))
                 .default_service(web::route().to(not_found))
         }, //.wrap(actix_web::middleware::Logger::default()))

--- a/cake-core/src/cake/api/text.rs
+++ b/cake-core/src/cake/api/text.rs
@@ -1,12 +1,12 @@
-use std::io::Write;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use actix_web::{HttpRequest, HttpResponse, Responder, web};
-use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 use crate::cake::Master;
 use crate::models::chat::Message;
 use crate::models::{ImageGenerator, TextGenerator};
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
 
 #[derive(Deserialize)]
 pub struct ChatRequest {
@@ -91,6 +91,8 @@ where
         .unwrap();
 
     let response = ChatResponse::from_assistant_response(TG::MODEL_NAME.to_string(), resp);
+
+    master.goodbye().await.unwrap();
 
     HttpResponse::Ok().json(response)
 }

--- a/cake-core/src/cake/client.rs
+++ b/cake-core/src/cake/client.rs
@@ -123,6 +123,11 @@ impl super::Forwarder for Client {
             .await
     }
 
+    async fn goodbye(&mut self) -> Result<()> {
+        self.request(Message::Goodbye).await?;
+        Ok(())
+    }
+
     fn layer_name(&self) -> &str {
         &self.layer_name
     }

--- a/cake-core/src/cake/master.rs
+++ b/cake-core/src/cake/master.rs
@@ -4,28 +4,38 @@ use crate::models::{chat::Message, ImageGenerator, TextGenerator};
 
 use super::{api, Context};
 
+use crate::{ImageGenerationArgs, ModelType};
 use anyhow::Result;
 use image::{ImageBuffer, Rgb};
-use crate::{ImageGenerationArgs, ModelType};
 
 /// A master connects to, communicates with and orchestrates the workers.
 pub struct Master<TG, IG> {
     pub ctx: Context,
     pub llm_model: Option<Box<TG>>,
-    pub sd_model: Option<Box<IG>>
+    pub sd_model: Option<Box<IG>>,
 }
 
-impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync + 'static> Master<TG, IG> {
+impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync + 'static>
+    Master<TG, IG>
+{
     /// Create a new instance.
     pub async fn new(mut ctx: Context) -> Result<Self> {
         match ctx.args.model_type {
             ModelType::ImageModel => {
                 let sd_model = IG::load(&mut ctx).await?;
-                Ok(Self { ctx, sd_model, llm_model: None })
-            },
+                Ok(Self {
+                    ctx,
+                    sd_model,
+                    llm_model: None,
+                })
+            }
             ModelType::TextModel => {
                 let llm_model = TG::load(&mut ctx).await?;
-                Ok(Self { ctx, llm_model, sd_model: None })
+                Ok(Self {
+                    ctx,
+                    llm_model,
+                    sd_model: None,
+                })
             }
         }
     }
@@ -37,7 +47,6 @@ impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync
         } else {
             // if running in cli mode, pre add system and user prompts
             if self.ctx.args.model_type == ModelType::TextModel {
-
                 let llm_model = self.llm_model.as_mut().expect("LLM model not found");
                 llm_model.add_message(Message::system(self.ctx.args.system_prompt.clone()))?;
                 llm_model.add_message(Message::user(self.ctx.args.prompt.clone()))?;
@@ -56,15 +65,16 @@ impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync
                 let mut step_num = 0;
 
                 self.generate_image(self.ctx.args.sd_img_gen_args.clone(), move |images| {
-
                     let mut batched_num = 0;
                     for image in images {
-                        image.save(format!("images/image_{}_{}.png", batched_num, step_num)).expect("Error saving image to disk");
-                        batched_num+=1;
+                        image
+                            .save(format!("images/image_{}_{}.png", batched_num, step_num))
+                            .expect("Error saving image to disk");
+                        batched_num += 1;
                     }
-                    step_num+=1;
-
-                }).await?;
+                    step_num += 1;
+                })
+                .await?;
             }
         }
 
@@ -73,7 +83,19 @@ impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync
 
     /// Reset the master state for a new inference.
     pub fn reset(&mut self) -> Result<()> {
-        self.llm_model.as_mut().expect("LLM model not found").reset()
+        self.llm_model
+            .as_mut()
+            .expect("LLM model not found")
+            .reset()
+    }
+
+    /// clear worker kv cache
+    pub async fn goodbye(&mut self) -> Result<()> {
+        self.llm_model
+            .as_mut()
+            .expect("LLM model not found")
+            .goodbye()
+            .await
     }
 
     /// Start the generation loop and call the stream function for every token.
@@ -87,8 +109,6 @@ impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync
         );
 
         log::debug!("  ctx.args.sample_len = {}", self.ctx.args.sample_len);
-
-        stream(&self.ctx.args.prompt);
 
         let mut start_gen = std::time::Instant::now();
         let llm_model = self.llm_model.as_mut().expect("LLM model not found");
@@ -125,7 +145,7 @@ impl<TG: TextGenerator + Send + Sync + 'static, IG: ImageGenerator + Send + Sync
 
     pub async fn generate_image<F>(&mut self, args: ImageGenerationArgs, callback: F) -> Result<()>
     where
-        F: FnMut(Vec<ImageBuffer<Rgb<u8>, Vec<u8>>>) + Send + 'static
+        F: FnMut(Vec<ImageBuffer<Rgb<u8>, Vec<u8>>>) + Send + 'static,
     {
         let sd_model = self.sd_model.as_mut().expect("SD model not found");
         sd_model.generate_image(&args, callback).await

--- a/cake-core/src/cake/mod.rs
+++ b/cake-core/src/cake/mod.rs
@@ -3,11 +3,14 @@ use std::{
     path::PathBuf,
 };
 
+use crate::{
+    models::llama3::{Cache, Config, LlamaConfig},
+    utils, Args, ModelType,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use crate::{models::llama3::{Cache, Config, LlamaConfig}, utils, Args, ModelType};
 
 #[cfg(feature = "master")]
 mod api;
@@ -73,16 +76,19 @@ impl Context {
         let data_path = PathBuf::from(&args.model);
         let topology = Topology::from_path(&args.topology, &args.model_type)?;
 
-        let mut config :Option<Config> = None;
+        let mut config: Option<Config> = None;
         let mut cache: Option<Cache> = None;
-        let mut var_builder:Option<VarBuilder> = None;
+        let mut var_builder: Option<VarBuilder> = None;
 
         if args.model_type == ModelType::TextModel {
             let config_filename = data_path.join("config.json");
             let config_internal = LlamaConfig::from_path(&config_filename)?.into_config();
             let model_tensors_index: PathBuf = data_path.join("model.safetensors.index.json");
-            var_builder =
-            Some(utils::load_var_builder_from_index(model_tensors_index, dtype, device.clone())?);
+            var_builder = Some(utils::load_var_builder_from_index(
+                model_tensors_index,
+                dtype,
+                device.clone(),
+            )?);
             cache = Some(Cache::new(true, dtype, &config_internal, &device)?);
             config = Some(config_internal);
         }
@@ -114,7 +120,7 @@ pub trait Forwarder: Debug + Send + Sync + Display {
         x: &Tensor,
         index_pos: usize,
         block_idx: usize,
-        ctx: &mut Context
+        ctx: &mut Context,
     ) -> Result<Tensor>;
 
     /// Applies a forward operation to the input tensor, requires mutability.
@@ -123,7 +129,7 @@ pub trait Forwarder: Debug + Send + Sync + Display {
         x: &Tensor,
         index_pos: usize,
         block_idx: usize,
-        ctx: &mut Context
+        ctx: &mut Context,
     ) -> Result<Tensor>;
 
     /// Applies a batch of forward operations to the input tensor.
@@ -131,8 +137,12 @@ pub trait Forwarder: Debug + Send + Sync + Display {
         &mut self,
         _x: &Tensor,
         _batch: Vec<(String, usize, usize)>,
-        _ctx: &mut Context
+        _ctx: &mut Context,
     ) -> Result<Tensor> {
+        unimplemented!()
+    }
+
+    async fn goodbye(&mut self) -> Result<()> {
         unimplemented!()
     }
 

--- a/cake-core/src/cake/proto/message.rs
+++ b/cake-core/src/cake/proto/message.rs
@@ -78,6 +78,8 @@ pub enum Message {
     },
     /// A message to transmit tensors.
     Tensor(RawTensor),
+    /// Last message sent.
+    Goodbye,
 }
 
 #[inline]

--- a/cake-core/src/cake/topology.rs
+++ b/cake-core/src/cake/topology.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
+use crate::ModelType;
 use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use crate::ModelType;
 
 lazy_static! {
     static ref LAYER_RANGE_PARSER: Regex = Regex::new(r"(?m)^(.+[^\d])(\d+)-(\d+)$").unwrap();
@@ -23,7 +23,6 @@ pub struct Node {
 impl Node {
     /// Return true if this node hosts the specified layer.
     pub fn is_text_model_layer_owner(&self, full_layer_name: &str) -> bool {
-
         for prefix in self.layers.iter() {
             if full_layer_name.starts_with(&format!("{}.", prefix)) {
                 return true;
@@ -49,7 +48,6 @@ impl Topology {
         if *model_type == ModelType::TextModel {
             // check for range expressions
             for (_worker_name, node) in topology.iter_mut() {
-
                 let mut layers = vec![];
                 for layer_name in &node.layers {
                     if let Some(caps) = LAYER_RANGE_PARSER.captures_iter(layer_name).next() {

--- a/cake-core/src/lib.rs
+++ b/cake-core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod utils;
 pub enum ModelType {
     #[default]
     TextModel,
-    ImageModel
+    ImageModel,
 }
 
 #[derive(Clone, Parser, Default, Debug)]
@@ -89,40 +89,40 @@ pub struct Args {
 
 #[derive(Clone, Parser, Default, Debug)]
 pub struct SDArgs {
-    #[arg(long="sd-tokenizer")]
+    #[arg(long = "sd-tokenizer")]
     pub tokenizer: Option<String>,
 
-    #[arg(long="sd-tokenizer-2")]
+    #[arg(long = "sd-tokenizer-2")]
     pub tokenizer_2: Option<String>,
 
-    #[arg(long="sd-version", value_enum, default_value = "v1-5")]
+    #[arg(long = "sd-version", value_enum, default_value = "v1-5")]
     sd_version: StableDiffusionVersion,
 
-    #[arg(long="sd-use-f16", default_value_t = true)]
+    #[arg(long = "sd-use-f16", default_value_t = true)]
     use_f16: bool,
 
-    #[arg(long="sd-width")]
+    #[arg(long = "sd-width")]
     width: Option<usize>,
 
-    #[arg(long="sd-height")]
+    #[arg(long = "sd-height")]
     height: Option<usize>,
 
-    #[arg(long="sd-sliced-attention-size")]
+    #[arg(long = "sd-sliced-attention-size")]
     sliced_attention_size: Option<usize>,
 
-    #[arg(long="sd-clip")]
+    #[arg(long = "sd-clip")]
     clip: Option<String>,
 
-    #[arg(long="sd-clip2")]
+    #[arg(long = "sd-clip2")]
     clip2: Option<String>,
 
-    #[arg(long="sd-vae")]
+    #[arg(long = "sd-vae")]
     vae: Option<String>,
 
-    #[arg(long="sd-unet")]
+    #[arg(long = "sd-unet")]
     unet: Option<String>,
 
-    #[arg(long="sd-use-flash-attention", default_value_t = false)]
+    #[arg(long = "sd-use-flash-attention", default_value_t = false)]
     use_flash_attention: bool,
 }
 
@@ -145,57 +145,63 @@ fn default_img2img_strength() -> f64 {
 #[derive(Clone, Parser, Default, Debug, Deserialize)]
 pub struct ImageGenerationArgs {
     /// The prompt to be used for image generation.
-    #[arg(long="sd-image-prompt",  default_value = "A very realistic photo of a rusty robot walking on a sandy beach")]
-    #[serde(rename(deserialize="sd-image-prompt"), default="default_prompt")]
+    #[arg(
+        long = "sd-image-prompt",
+        default_value = "A very realistic photo of a rusty robot walking on a sandy beach"
+    )]
+    #[serde(rename(deserialize = "sd-image-prompt"), default = "default_prompt")]
     image_prompt: String,
 
-    #[arg(long="sd-uncond-prompt", default_value = "")]
-    #[serde(rename(deserialize="sd-uncond-prompt"), default="empty_str")]
+    #[arg(long = "sd-uncond-prompt", default_value = "")]
+    #[serde(rename(deserialize = "sd-uncond-prompt"), default = "empty_str")]
     uncond_prompt: String,
 
     /// Enable tracing (generates a trace-timestamp.json file).
-    #[arg(long="sd-tracing", default_value_t = false)]
-    #[serde(rename(deserialize="sd-tracing"), default)]
+    #[arg(long = "sd-tracing", default_value_t = false)]
+    #[serde(rename(deserialize = "sd-tracing"), default)]
     tracing: bool,
 
     /// The number of steps to run the diffusion for.
-    #[arg(long="sd-n-steps")]
-    #[serde(rename(deserialize="sd-n-steps"))]
+    #[arg(long = "sd-n-steps")]
+    #[serde(rename(deserialize = "sd-n-steps"))]
     n_steps: Option<usize>,
 
     /// The number of samples to generate iteratively.
-    #[arg(long="sd-num-samples", default_value_t = 1)]
-    #[serde(rename(deserialize="sd-num-samples"), default="usize_one")]
+    #[arg(long = "sd-num-samples", default_value_t = 1)]
+    #[serde(rename(deserialize = "sd-num-samples"), default = "usize_one")]
     num_samples: usize,
 
     /// The numbers of samples to generate simultaneously.
-    #[arg(long="sd-bsize", default_value_t = 1)]
-    #[serde(rename(deserialize="sd-bsize"), default="usize_one")]
+    #[arg(long = "sd-bsize", default_value_t = 1)]
+    #[serde(rename(deserialize = "sd-bsize"), default = "usize_one")]
     bsize: usize,
 
     /// Generate intermediary images every n steps.
-    #[arg(long="sd-intermediary-images", default_value_t = 0, action)]
-    #[serde(rename(deserialize="sd-intermediary-images"), default)]
+    #[arg(long = "sd-intermediary-images", default_value_t = 0, action)]
+    #[serde(rename(deserialize = "sd-intermediary-images"), default)]
     intermediary_images: usize,
 
-    #[arg(long="sd-guidance-scale")]
-    #[serde(rename(deserialize="sd-guidance-scale"))]
+    #[arg(long = "sd-guidance-scale")]
+    #[serde(rename(deserialize = "sd-guidance-scale"))]
     guidance_scale: Option<f64>,
 
-    #[arg(long="sd-img2img", value_name = "FILE")]
-    #[serde(rename(deserialize="sd-img2img"))]
+    #[arg(long = "sd-img2img", value_name = "FILE")]
+    #[serde(rename(deserialize = "sd-img2img"))]
     img2img: Option<String>,
 
     /// The strength, indicates how much to transform the initial image. The
     /// value must be between 0 and 1, a value of 1 discards the initial image
     /// information.
-    #[arg(long="sd-img2img-strength", default_value_t = 0.8)]
-    #[serde(rename(deserialize="sd-img2img-strength"), default="default_img2img_strength")]
+    #[arg(long = "sd-img2img-strength", default_value_t = 0.8)]
+    #[serde(
+        rename(deserialize = "sd-img2img-strength"),
+        default = "default_img2img_strength"
+    )]
     img2img_strength: f64,
 
     /// The seed to use when generating random samples.
-    #[arg(long="sd-seed")]
-    #[serde(rename(deserialize="sd-seed"))]
+    #[arg(long = "sd-seed")]
+    #[serde(rename(deserialize = "sd-seed"))]
     image_seed: Option<u64>,
 }
 

--- a/cake-core/src/models/llama3/history.rs
+++ b/cake-core/src/models/llama3/history.rs
@@ -1,6 +1,7 @@
 use crate::models::chat::Message;
 
 /// Chat history.
+#[derive(Debug)]
 pub struct History(Vec<Message>);
 
 // Adapted from https://github.com/meta-llama/llama3/blob/main/llama/tokenizer.py#L202

--- a/cake-core/src/models/llama3/llama.rs
+++ b/cake-core/src/models/llama3/llama.rs
@@ -5,12 +5,12 @@ use candle_nn::{linear_no_bias as linear, Embedding, Linear, Module, RmsNorm};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use tokenizers::Tokenizer;
 
+use super::{transformer::Transformer, History};
+use crate::models::TextGenerator;
 use crate::{
     cake::{Context, Forwarder},
     models::{chat::Message, Generator, Token},
 };
-use crate::models::TextGenerator;
-use super::{transformer::Transformer, History};
 
 /// Default end of stream token if not found in configuration.
 const DEFAULT_EOS_TOKEN: &str = "</s>";
@@ -24,7 +24,9 @@ fn load_tokenizer(ctx: &Context) -> Result<(Tokenizer, Option<u32>)> {
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(anyhow::Error::msg)?;
 
     let eos_token_id = ctx
-        .config.as_ref().expect("No config specified")
+        .config
+        .as_ref()
+        .expect("No config specified")
         .eos_token_id
         .or_else(|| tokenizer.token_to_id(DEFAULT_EOS_TOKEN));
 
@@ -166,14 +168,13 @@ impl LLama {
     }
 }
 
- #[async_trait]
+#[async_trait]
 impl Generator for LLama {
     type Shardable = Transformer;
     const MODEL_NAME: &'static str = "llama3";
 
     /// Load this model from the context.
     async fn load(ctx: &mut Context) -> Result<Option<Box<Self>>> {
-
         let config = ctx.config.as_ref().expect("No config specified");
         let var_builder = ctx.var_builder.as_ref().expect("No var_builder specified");
 
@@ -212,10 +213,7 @@ impl Generator for LLama {
                 ));
             } else {
                 log::debug!("{} will be served locally", &block_layer_name);
-                blocks.push(Transformer::load(
-                    block_layer_name.clone(),
-                    &ctx,
-                )?);
+                blocks.push(Transformer::load(block_layer_name.clone(), &ctx)?);
             }
         }
 
@@ -256,7 +254,6 @@ impl Generator for LLama {
 
 #[async_trait]
 impl TextGenerator for LLama {
-
     /// Add a message to the chat history.
     fn add_message(&mut self, message: Message) -> Result<()> {
         self.history.push(message);
@@ -273,6 +270,19 @@ impl TextGenerator for LLama {
         Ok(())
     }
 
+    async fn goodbye(&mut self) -> Result<()> {
+        let num_blocks = self.blocks.len();
+        let mut block_idx = 0;
+        while block_idx < num_blocks {
+            self.blocks[block_idx]
+                .goodbye()
+                .await
+                .map_err(|e| anyhow!("error in reset operation for block {block_idx}: {e}"))?;
+            block_idx += 1;
+        }
+        Ok(())
+    }
+
     /// Return the next token.
     async fn next_token(&mut self, index: usize) -> Result<Token> {
         log::trace!("model.next_token({index})");
@@ -283,7 +293,14 @@ impl TextGenerator for LLama {
         }
 
         let num_tokens = self.tokens.len();
-        let (context_size, context_index) = if self.ctx.cache.as_ref().expect("No cache specified").with_kv_cache() && index > 0 {
+        let (context_size, context_index) = if self
+            .ctx
+            .cache
+            .as_ref()
+            .expect("No cache specified")
+            .with_kv_cache()
+            && index > 0
+        {
             (1, self.index_pos)
         } else {
             (num_tokens, 0)
@@ -296,8 +313,6 @@ impl TextGenerator for LLama {
         let input = Tensor::new(context_tokens, &self.ctx.device)?
             .unsqueeze(0)
             .map_err(|e| anyhow!("error squeezing context tokens: {e}"))?;
-
-        // log::info!("input={:?} context_index={context_index}", input.shape());
 
         let logits = self
             .forward(&input, context_index)

--- a/cake-core/src/models/llama3/transformer.rs
+++ b/cake-core/src/models/llama3/transformer.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use candle_core::Tensor;
 use candle_nn::{Module, RmsNorm};
 
-use async_trait::async_trait;
 use crate::cake::{Context, Forwarder};
+use async_trait::async_trait;
 
 use super::{CausalSelfAttention, MLP};
 
@@ -26,7 +26,6 @@ impl std::fmt::Display for Transformer {
 #[async_trait]
 impl Forwarder for Transformer {
     fn load(name: String, ctx: &Context) -> Result<Box<Self>> {
-
         let vb = ctx.var_builder.as_ref().expect("No var_builder specified");
         let cfg = ctx.config.as_ref().expect("No config specified");
 
@@ -60,7 +59,12 @@ impl Forwarder for Transformer {
         let x = self.rms_1.forward(x).map_err(|e| anyhow!("rms_1: {e}"))?;
         let x = (self
             .attn
-            .forward(&x, index_pos, block_idx, &mut ctx.cache.as_mut().expect("No cache specified"))
+            .forward(
+                &x,
+                index_pos,
+                block_idx,
+                &mut ctx.cache.as_mut().expect("No cache specified"),
+            )
             .map_err(|e| anyhow!("attention: {e}"))?
             + residual)
             .map_err(|e| anyhow!("residual: {e}"))?;

--- a/cake-core/src/models/mod.rs
+++ b/cake-core/src/models/mod.rs
@@ -38,7 +38,6 @@ impl std::fmt::Display for Token {
 /// A model must implement this trait in order to be usable by the Cake framework.
 #[async_trait]
 pub trait Generator {
-
     /// This associated type determines which part of the model can be sharded.
     type Shardable: Forwarder;
 
@@ -51,11 +50,13 @@ pub trait Generator {
 
 #[async_trait]
 pub trait TextGenerator: Generator {
-
     /// Add a message to the chat.
     fn add_message(&mut self, message: Message) -> Result<()>;
     /// Clear chat history.
     fn reset(&mut self) -> Result<()>;
+
+    /// clear worker kv cache
+    async fn goodbye(&mut self) -> Result<()>;
 
     /// Return the next token.
     async fn next_token(&mut self, index: usize) -> Result<Token>;
@@ -65,7 +66,11 @@ pub trait TextGenerator: Generator {
 
 #[async_trait]
 pub trait ImageGenerator: Generator {
-    async fn generate_image<F>(&mut self, args: &ImageGenerationArgs, mut callback: F) -> Result<(), anyhow::Error>
+    async fn generate_image<F>(
+        &mut self,
+        args: &ImageGenerationArgs,
+        mut callback: F,
+    ) -> Result<(), anyhow::Error>
     where
         F: FnMut(Vec<ImageBuffer<Rgb<u8>, Vec<u8>>>) + Send + 'static;
 }

--- a/cake-core/src/models/sd/mod.rs
+++ b/cake-core/src/models/sd/mod.rs
@@ -1,10 +1,10 @@
-mod unet;
-mod vae;
 mod clip;
+mod safe_scheduler;
 mod sd;
 mod sd_shardable;
+mod unet;
 mod util;
-mod safe_scheduler;
+mod vae;
 
 pub use sd::*;
 pub use util::*;

--- a/cake-core/src/models/sd/sd_shardable.rs
+++ b/cake-core/src/models/sd/sd_shardable.rs
@@ -1,10 +1,10 @@
-use std::fmt::{Debug, Display, Formatter};
-use async_trait::async_trait;
-use candle_core::Tensor;
 use crate::cake::{Context, Forwarder};
 use crate::models::sd::clip::Clip;
 use crate::models::sd::unet::UNet;
 use crate::models::sd::vae::VAE;
+use async_trait::async_trait;
+use candle_core::Tensor;
+use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug)]
 pub struct SDShardable {
@@ -22,43 +22,62 @@ impl Display for SDShardable {
 impl Forwarder for SDShardable {
     fn load(name: String, ctx: &Context) -> anyhow::Result<Box<Self>>
     where
-        Self: Sized
+        Self: Sized,
     {
         let model: Box<dyn Forwarder>;
 
         match name.as_str() {
             "vae" => {
                 model = VAE::load(name.clone(), ctx)?;
-            },
+            }
             "clip" => {
                 model = Clip::load(name.clone(), ctx)?;
-            },
+            }
             "clip2" => {
                 model = Clip::load(name.clone(), ctx)?;
-            },
+            }
             "unet" => {
                 model = UNet::load(name.clone(), ctx)?;
-            },
+            }
             _ => {
                 anyhow::bail!("Model name not recognized");
             }
         }
 
-        Ok(Box::new(Self{
+        Ok(Box::new(Self {
             forwarder: model,
-            layer_name: name
+            layer_name: name,
         }))
     }
 
-    async fn forward(&self, x: &Tensor, index_pos: usize, block_idx: usize, ctx: &mut Context) -> anyhow::Result<Tensor> {
+    async fn forward(
+        &self,
+        x: &Tensor,
+        index_pos: usize,
+        block_idx: usize,
+        ctx: &mut Context,
+    ) -> anyhow::Result<Tensor> {
         self.forwarder.forward(x, index_pos, block_idx, ctx).await
     }
 
-    async fn forward_mut(&mut self, x: &Tensor, index_pos: usize, block_idx: usize, ctx: &mut Context) -> anyhow::Result<Tensor> {
-        self.forwarder.forward_mut(x, index_pos, block_idx, ctx).await
+    async fn forward_mut(
+        &mut self,
+        x: &Tensor,
+        index_pos: usize,
+        block_idx: usize,
+        ctx: &mut Context,
+    ) -> anyhow::Result<Tensor> {
+        self.forwarder
+            .forward_mut(x, index_pos, block_idx, ctx)
+            .await
     }
 
-    async fn forward_batch(&mut self, _x: &Tensor, _batch: Vec<(String, usize, usize)>, ctx: &mut Context) -> anyhow::Result<Tensor> {
+    async fn forward_batch(
+        &mut self,
+        _x: &Tensor,
+        _batch: Vec<(String, usize, usize)>,
+        ctx: &mut Context,
+    ) -> anyhow::Result<Tensor> {
         self.forwarder.forward_batch(_x, _batch, ctx).await
     }
 

--- a/cake-core/src/models/sd/unet.rs
+++ b/cake-core/src/models/sd/unet.rs
@@ -1,17 +1,17 @@
-use std::fmt::{Debug, Display, Formatter};
-use async_trait::async_trait;
-use candle_core::{Device, DType, Tensor};
-use candle_transformers::models::stable_diffusion::StableDiffusionConfig;
-use candle_transformers::models::stable_diffusion::unet_2d::UNet2DConditionModel;
 use crate::cake::{Context, Forwarder};
-use crate::models::sd::ModelFile;
 use crate::models::sd::util::{get_sd_config, pack_tensors, unpack_tensors};
+use crate::models::sd::ModelFile;
 use crate::StableDiffusionVersion;
+use async_trait::async_trait;
+use candle_core::{DType, Device, Tensor};
+use candle_transformers::models::stable_diffusion::unet_2d::UNet2DConditionModel;
+use candle_transformers::models::stable_diffusion::StableDiffusionConfig;
 use log::info;
+use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug)]
 pub struct UNet {
-    unet_model: UNet2DConditionModel
+    unet_model: UNet2DConditionModel,
 }
 
 impl Display for UNet {
@@ -24,7 +24,7 @@ impl Display for UNet {
 impl Forwarder for UNet {
     fn load(_name: String, ctx: &Context) -> anyhow::Result<Box<Self>>
     where
-        Self: Sized
+        Self: Sized,
     {
         let sd_config = get_sd_config(ctx)?;
 
@@ -40,7 +40,13 @@ impl Forwarder for UNet {
         )
     }
 
-    async fn forward(&self, x: &Tensor, _index_pos: usize, _block_idx: usize, ctx: &mut Context) -> anyhow::Result<Tensor> {
+    async fn forward(
+        &self,
+        x: &Tensor,
+        _index_pos: usize,
+        _block_idx: usize,
+        ctx: &mut Context,
+    ) -> anyhow::Result<Tensor> {
         let unpacked_tensors = unpack_tensors(x)?;
         let latent_model_input = &unpacked_tensors[0].to_dtype(ctx.dtype)?;
         let text_embeddings = &unpacked_tensors[1].to_dtype(ctx.dtype)?;
@@ -50,11 +56,20 @@ impl Forwarder for UNet {
         let timestep_f32: &f32 = timestep_vec.get(0).expect("Error retrieving timestep");
 
         info!("UNet model forwarding...");
-        
-        Ok(self.unet_model.forward(latent_model_input, *timestep_f32 as f64, text_embeddings).expect("Error running UNet forward"))
+
+        Ok(self
+            .unet_model
+            .forward(latent_model_input, *timestep_f32 as f64, text_embeddings)
+            .expect("Error running UNet forward"))
     }
 
-    async fn forward_mut(&mut self, x: &Tensor, index_pos: usize, block_idx: usize, ctx: &mut Context) -> anyhow::Result<Tensor> {
+    async fn forward_mut(
+        &mut self,
+        x: &Tensor,
+        index_pos: usize,
+        block_idx: usize,
+        ctx: &mut Context,
+    ) -> anyhow::Result<Tensor> {
         self.forward(x, index_pos, block_idx, ctx).await
     }
 
@@ -64,18 +79,25 @@ impl Forwarder for UNet {
 }
 
 impl UNet {
-    pub fn load_model(name: Option<String>, use_flash_attn: bool, version: StableDiffusionVersion, use_f16: bool, device: &Device, dtype: DType, cache_dir: String, config: &StableDiffusionConfig) -> anyhow::Result<Box<Self>>
+    pub fn load_model(
+        name: Option<String>,
+        use_flash_attn: bool,
+        version: StableDiffusionVersion,
+        use_f16: bool,
+        device: &Device,
+        dtype: DType,
+        cache_dir: String,
+        config: &StableDiffusionConfig,
+    ) -> anyhow::Result<Box<Self>>
     where
-        Self: Sized {
-
+        Self: Sized,
+    {
         let unet_weights = ModelFile::Unet.get(name, version, use_f16, cache_dir)?;
         let unet = config.build_unet(unet_weights, &device, 4, use_flash_attn, dtype)?;
 
         info!("Loading UNet model...");
-        
-        Ok(Box::new(Self{
-            unet_model: unet,
-        }))
+
+        Ok(Box::new(Self { unet_model: unet }))
     }
 
     pub async fn forward_unpacked(
@@ -83,17 +105,12 @@ impl UNet {
         latent_model_input: Tensor,
         text_embeddings: Tensor,
         timestep: usize,
-        ctx: &mut Context
+        ctx: &mut Context,
     ) -> anyhow::Result<Tensor> {
-
         // Pack the tensors to be sent into one
         let timestep_tensor = Tensor::from_slice(&[timestep as f32], 1, &ctx.device)?;
 
-        let tensors = Vec::from([
-            latent_model_input,
-            text_embeddings,
-            timestep_tensor
-        ]);
+        let tensors = Vec::from([latent_model_input, text_embeddings, timestep_tensor]);
 
         let combined_tensor = pack_tensors(tensors, &ctx.device)?;
         Ok(forwarder.forward_mut(&combined_tensor, 0, 0, ctx).await?)

--- a/cake-ios/Cargo.toml
+++ b/cake-ios/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate_type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib"]
 name = "cake"
 
 [dependencies]

--- a/cake-ios/src/lib.rs
+++ b/cake-ios/src/lib.rs
@@ -1,22 +1,25 @@
 //! This is a small library that wraps cake-core and exposes it as an API to the Swift side of things on iOS.
 uniffi::setup_scaffolding!();
 
-use cake_core::{cake::{Context, Mode, Worker}, Args, ModelType};
+use cake_core::{
+    cake::{Context, Mode, Worker},
+    Args, ModelType,
+};
 
 #[uniffi::export]
 pub fn start_worker(name: String, model_path: String, topology_path: String, model_type: String) {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
 
     log::debug!("@ creating context");
-    
+
     log::debug!("@ model type: {model_type}");
 
     let model_type_arg = match model_type.as_str() {
         "text" => ModelType::TextModel,
         "image" => ModelType::ImageModel,
-        _ => panic!("Unrecognized model type")
+        _ => panic!("Unrecognized model type"),
     };
-    
+
     let args = Args {
         address: "0.0.0.0:10128".to_string(),
         mode: Mode::Worker,
@@ -41,16 +44,17 @@ pub fn start_worker(name: String, model_path: String, topology_path: String, mod
         .unwrap()
         .block_on(async {
             log::debug!("@ creating worker");
-            
+
             match model_type.as_str() {
                 "text" => {
-                    let mut worker = match Worker::<cake_core::models::llama3::LLama>::new(&mut ctx).await {
-                        Ok(w) => w,
-                        Err(e) => {
-                            log::error!("ERROR: {}", e);
-                            return;
-                        }
-                    };
+                    let mut worker =
+                        match Worker::<cake_core::models::llama3::LLama>::new(&mut ctx).await {
+                            Ok(w) => w,
+                            Err(e) => {
+                                log::error!("ERROR: {}", e);
+                                return;
+                            }
+                        };
 
                     log::info!("@ running worker for text model...");
 
@@ -60,9 +64,10 @@ pub fn start_worker(name: String, model_path: String, topology_path: String, mod
                             log::error!("ERROR: {}", e);
                         }
                     }
-                },
+                }
                 "image" => {
-                    let mut worker = match Worker::<cake_core::models::sd::SD>::new(&mut ctx).await {
+                    let mut worker = match Worker::<cake_core::models::sd::SD>::new(&mut ctx).await
+                    {
                         Ok(w) => w,
                         Err(e) => {
                             log::error!("ERROR: {}", e);
@@ -78,7 +83,7 @@ pub fn start_worker(name: String, model_path: String, topology_path: String, mod
                             log::error!("ERROR: {}", e);
                         }
                     }
-                },
+                }
                 _ => {
                     log::error!("ERROR: unrecognized model type");
                 }

--- a/cake-split-model/src/main.rs
+++ b/cake-split-model/src/main.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use anyhow::Result;
-use cake_core::{cake::{Node, Topology}, ModelType, utils};
+use cake_core::{
+    cake::{Node, Topology},
+    utils, ModelType,
+};
 use clap::Parser;
 use safetensors::{Dtype, SafeTensors, View};
 use serde::{Deserialize, Serialize};
@@ -142,7 +145,8 @@ fn main() {
     let args = Args::parse();
     let data_path = PathBuf::from(&args.model_path);
 
-    let topology = Topology::from_path(&args.topology, &ModelType::TextModel).expect("can't load topology");
+    let topology =
+        Topology::from_path(&args.topology, &ModelType::TextModel).expect("can't load topology");
     let index = load_index(&data_path).expect("can't load index");
 
     println!("index has {} tensors", index.weight_map.len());


### PR DESCRIPTION
Fix second inference error https://github.com/evilsocket/cake/issues/26.

This error was caused by not properly clearing the kv cache on the worker node, so I added a goodbye message from the master node to clear the kv cache on the worker nodes.

And some other update is caused by `cargo fmt`