### PR TITLE
fix: link CoreGraphics framework for Metal device detection

### DIFF
--- a/cake-core/build.rs
+++ b/cake-core/build.rs
@@ -1,4 +1,8 @@
 fn main() {
+    #[cfg(feature = "metal")]
+    {
+        println!("cargo:rustc-link-lib=framework=CoreGraphics");
+    }
     #[cfg(feature = "vulkan")]
     {
         println!("cargo::rerun-if-changed=src/backends/vulkan/ops.wgsl");


### PR DESCRIPTION
 ## Summary

`cake chat` panics on a fresh macOS clone with `--features metal`:

```
swap_remove index (is 0) should be < len (is 0)
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: alloc::vec::Vec<T,A>::swap_remove::assert_failed
   3: candle_core::metal_backend::<impl candle_core::backend::BackendDevice for candle_core::metal_backend::device::MetalDevice>::new
   4: cake_core::utils::get_inference_device
   5: cake_core::cake::Context::from_args
   6: cake::main::{{closure}}
   7: tokio::runtime::runtime::Runtime::block_on
   8: cake::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
zsh: abort      RUST_BACKTRACE=1 ./target/release/cake chat Qwen/Qwen3-0.6B
```

### Fix

- The call chain leads us to `candle_core` and `candle-metal-kernels` [lines 50-55](https://docs.rs/crate/candle-metal-kernels/0.9.2/source/src/metal/device.rs#50) which calls `MTLCreateSystemDefaultDevice()` and collects into a Vec.
- `MTLCreateSystemDefaultDevice()` returns `None` because CoreGraphics is not linked. Documented requirement in `objc2-metal` (see [objc2-metal/src/lib.rs lines 14-16](https://github.com/madsmtm/objc2/blob/master/framework-crates/objc2-metal/src/lib.rs#L14-L16)):

  > NOTE: To use `MTLCreateSystemDefaultDevice` you need to link to `CoreGraphics`

- `candle-metal-kernels` doesn't add this linkage, and neither does cake
- One line fix in `cake-core/build.rs`
- Verified chat works on metal after fix