### PR TITLE
chore: ignore cake-mobile-app iOS build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,10 @@ topology-*.yml
 # Autoresearch generated files (machine-specific)
 autoresearch/**/baseline.txt
 autoresearch/**/experiments.tsv
+
+# cake-mobile-app iOS build artifacts
+cake-mobile-app/iosApp/iosApp.xcodeproj/project.xcworkspace/
+cake-mobile-app/iosApp/iosApp/Frameworks/
+cake-mobile-app/iosApp/iosApp/Generated/
+cake-mobile-app/iosApp/libcake_mobile.a
+cake-mobile-app/shared/build/


### PR DESCRIPTION
Adds five paths to root `.gitignore` for build artifacts that get
generated when working on the iOS side of cake-mobile-app:

- `cake-mobile-app/iosApp/iosApp.xcodeproj/project.xcworkspace/`
- `cake-mobile-app/iosApp/iosApp/Frameworks/`
- `cake-mobile-app/iosApp/iosApp/Generated/`
- `cake-mobile-app/iosApp/libcake_mobile.a`
- `cake-mobile-app/shared/build/`

Pairs with the existing `cake-mobile-app/.gradle/` and
`cake-mobile-app/build/` entries. None of the new paths are tracked
in git, so the .gitignore additions alone are sufficient.