### PR TITLE
fix: unused TextModelArch import when luxtts feature is disabled

### DIFF
--- a/cake-cli/src/main.rs
+++ b/cake-cli/src/main.rs
@@ -7,7 +7,7 @@ mod chat;
 
 use cake_core::{
     cake::{self, Context, Mode, Worker},
-    utils, Args, ImageModelArch, ModelType, TextModelArch,
+    utils, Args, ImageModelArch, ModelType,
 };
 
 use anyhow::Result;
@@ -318,7 +318,7 @@ pub(crate) async fn run_master(ctx: Context) -> Result<()> {
 
     // LuxTTS: TTS model using TextModel dispatch for sharding
     #[cfg(feature = "luxtts")]
-    if ctx.text_model_arch == TextModelArch::LuxTTS {
+    if ctx.text_model_arch == cake_core::TextModelArch::LuxTTS {
         return run_master_luxtts(ctx).await;
     }
 


### PR DESCRIPTION
## Problem

`TextModelArch` is imported unconditionally in `cake-cli/src/main.rs:10`, but its only use site is inside a `#[cfg(feature = "luxtts")]` block in `run_master` (`cake-cli/src/main.rs:321`). Building the CLI without that feature warns:

```
warning: unused import: `TextModelArch`
  --> cake-cli/src/main.rs:10:45
   |
10 |     utils, Args, ImageModelArch, ModelType, TextModelArch,
   |                                             ^^^^^^^^^^^^^
```

Reproduce:

```sh
cargo build --release -p cake-cli --no-default-features \
  --features "master,llama,qwen2,qwen3"
```

This breaks the zero-warning clippy requirement in `CLAUDE.md` for any reduced-feature build of the CLI.

## Why it went unnoticed

`luxtts` is in the default feature set, so the import is always used in a normal build. And no CI job builds `cake-cli` with `--no-default-features`:

- the `clippy` job (`ci.yml:294`) lints `cake-cli` with default features plus `vulkan,rocm`
- the `test-android` job builds with reduced features, but only targets `cake-core` and `cake-mobile` — never the CLI
- the same is true of `test-ios`

## Fix

Drop the import and fully qualify the path at the use site, matching the adjacent `cake_core::dispatch_text_model!` call:

```diff
-    utils, Args, ImageModelArch, ModelType, TextModelArch,
+    utils, Args, ImageModelArch, ModelType,
```

```diff
     #[cfg(feature = "luxtts")]
-    if ctx.text_model_arch == TextModelArch::LuxTTS {
+    if ctx.text_model_arch == cake_core::TextModelArch::LuxTTS {
```

This stays valid under every feature combination and avoids adding a second `#[cfg]` attribute that would have to be kept in sync with the one at the use site.

## Verification

Relying on the existing `clippy` job to confirm the default-feature build is unaffected, since removing an import is the direction that could regress. Not yet built locally with the full default feature set.

## Context

Found while building for Termux/Android on-device, where a reduced feature set is necessary to keep compile time and memory usage in range.

Happy to follow up with a CI step that covers this configuration so it can't regress:

```yaml
- name: Clippy (cake-cli, minimal features)
  run: cargo clippy -p cake-cli --no-default-features --features "master,llama,qwen2,qwen3" -- -D warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
