### PR TITLE
fix: cake serve fails with "required argument was not provided: address"

### DIFF
--- a/cake-cli/src/main.rs
+++ b/cake-cli/src/main.rs
@@ -44,7 +44,7 @@ enum Commands {
         model: String,
         /// API bind address
         #[arg(long = "api", default_value = "0.0.0.0:8080")]
-        address: String,
+        api_address: String,
         #[command(flatten)]
         args: Args,
     },
@@ -135,9 +135,9 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Commands::Serve { model, address, mut args } => {
+        Commands::Serve { model, api_address, mut args } => {
             args.model = model;
-            args.api = Some(address);
+            args.api = Some(api_address);
             args.mode = Mode::Master;
             run_as_master(args).await
         }


### PR DESCRIPTION
## Problem

`cake serve <model>` does not work in any release build:

```
$ cake serve evilsocket/Qwen3-0.6B
error: The following required argument was not provided: address

Usage: cake <COMMAND>

For more information, try '--help'.
```

No combination of flags gets past it — `address` has a default value in the source, so there is nothing the user can pass to satisfy it.

This affects every release build regardless of feature selection. `cake serve` is documented in the README and in `docs/api.md` as the way to start the API server.

## Cause

Clap derives an argument's ID from the **field name**, not from the `long` attribute. The `Serve` variant declares a field named `address` and also flattens `Args`, which has its own `address` field:

```rust
// cake-cli/src/main.rs:41
Serve {
    #[arg(id = "model_name")]
    model: String,

    #[arg(long = "api", default_value = "0.0.0.0:8080")]
    address: String,              // clap ID: "address", flag: --api

    #[command(flatten)]
    args: Args,                   // Args::address -> ID: "address", flag: --address
},
```

```rust
// cake-core/src/lib.rs:162
#[arg(long, default_value = "0.0.0.0:10128")]
pub address: String,
```

Both register under the ID `"address"` in the same command.

Clap validates ID uniqueness with debug assertions, which `--release` compiles out. Rather than panicking with a clear message, the built command ends up with a malformed argument table: both default values are dropped, `address` is treated as required, and the usage line degenerates to `cake <COMMAND>` instead of a real one.

`Run` is unaffected — it flattens `Args` without declaring an `address` field of its own.

## Workaround for anyone hitting this

`Serve` only sets `args.api` before delegating to the same code path as `Run`:

```rust
Commands::Serve { model, address, mut args } => {
    args.model = model;
    args.api = Some(address);
    args.mode = Mode::Master;
    run_as_master(args).await
}
```

So this is an exact equivalent and does work today:

```sh
cake run <model> --api 0.0.0.0:8080
```

## Fix

Rename the field to `api_address`, removing the collision:

```diff
     #[arg(long = "api", default_value = "0.0.0.0:8080")]
-        address: String,
+        api_address: String,
```

```diff
-        Commands::Serve { model, address, mut args } => {
+        Commands::Serve { model, api_address, mut args } => {
             args.model = model;
-            args.api = Some(address);
+            args.api = Some(api_address);
```

Renaming was chosen over adding `#[arg(id = "...")]` because it makes the field name match the flag it produces, so the collision is harder to reintroduce later.

No user-facing flags change: `--api` and `--address` continue to behave as documented.

## Context

Found while running cake on Android/Termux. The workaround above was verified working on that device; `cake run <model> --api 0.0.0.0:8080` serves the OpenAI-compatible API correctly.

Worth noting that no test currently exercises the CLI's argument parsing, which is why a broken headline subcommand could ship. A `Cli::command().debug_assert()` test would have caught this at build time — clap provides it for exactly this purpose:

```rust
#[test]
fn verify_cli() {
    use clap::CommandFactory;
    Cli::command().debug_assert();
}
```

Happy to add that in a follow-up if it would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
